### PR TITLE
Tcat/new active tasks

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -11,11 +11,11 @@ apply plugin: "kotlin-kapt"
 version = '2.0.0-SNAPSHOT'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdkVersion 26
+        targetSdkVersion 29
         versionCode 7
         versionName version
         vectorDrawables.useSupportLibrary = true
@@ -119,10 +119,14 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.7.1'
     testImplementation 'org.powermock:powermock-module-junit4:1.7.1'
 
-
-
     testImplementation 'org.robolectric:robolectric:4.2.1'
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+
+    // Required for camera support face detection
+    implementation "androidx.camera:camera-camera2:1.0.1"
+    implementation "androidx.camera:camera-lifecycle:1.0.1"
+    implementation "androidx.camera:camera-view:1.0.0-alpha27"
+    implementation 'com.google.mlkit:face-detection:16.1.2'
 }
 
 

--- a/backbone/src/main/AndroidManifest.xml
+++ b/backbone/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <!-- We allow users to secure their data using their fingerprint see -->
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
-
+    
     <!-- ActiveSteps may vibrate the phone on start and on finish -->
     <!-- Apps should include this if you want ActiveSteps to vibrate -->
     <!-- <uses-permission android:name="android.permission.VIBRATE"/> -->
@@ -16,5 +16,24 @@
 
     <!-- Needs to be added if your app uses an task with AudioStep -->
     <!--<uses-permission android:name="android.permission.RECORD_AUDIO" /> -->
+
+    <!-- Needs to be added if your app requires image capture using the camera -->
+    <!-- <uses-permission android:name="android.permission.CAMERA"/> -->
+    <!-- <uses-feature android:name="android.hardware.camera.any" /> -->
+
+    <!-- Needs to be added if your app must write files to external storage -->
+    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/> -->
+
+    <!-- Required to write files to internal app storage in the files directory -->
+    <!-- <provider
+        android:name="androidx.core.content.FileProvider"
+        android:authorities="org.researchstack.backbone.fileprovider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+        <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/file_paths">
+        </meta-data>
+    </provider> -->
 
 </manifest>

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveAudioCaptureStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveAudioCaptureStep.java
@@ -1,0 +1,28 @@
+package org.researchstack.backbone.step.active;
+
+import org.researchstack.backbone.ui.step.layout.ActiveAudioCaptureStepLayout;
+
+public class ActiveAudioCaptureStep extends ActiveStep {
+
+    private String instructionsText;
+
+    public ActiveAudioCaptureStep(String identifier, String title, String detailText, int duration) {
+        super(identifier, title, detailText);
+        if (duration <= 0)
+            throw new IllegalArgumentException("Step duration must be greater than 0");
+        setStepDuration(duration);
+    }
+
+    public Class getStepLayoutClass() {
+        return ActiveAudioCaptureStepLayout.class;
+    }
+
+    public void setInstructionsText(String instructionsText) {
+        this.instructionsText = instructionsText;
+    }
+
+    public String getInstructionsText() {
+        return this.instructionsText;
+    }
+
+}

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
@@ -1,0 +1,44 @@
+package org.researchstack.backbone.step.active;
+
+import android.graphics.Canvas;
+import android.media.Image;
+
+import com.google.mlkit.vision.face.Face;
+
+import org.researchstack.backbone.ui.step.layout.ActiveSelfieCaptureStepLayout;
+
+import java.io.Serializable;
+
+public class ActiveSelfieCaptureStep extends ActiveStep {
+
+    private String instructionsText;
+    private FaceDetectListener faceDetectListener;
+
+    public ActiveSelfieCaptureStep(String identifier, String title, String detailText) {
+        super(identifier, title, detailText);
+    }
+
+    public Class getStepLayoutClass() {
+        return ActiveSelfieCaptureStepLayout.class;
+    }
+
+    public void setInstructionsText(String instructionsText) {
+        this.instructionsText = instructionsText;
+    }
+
+    public String getInstructionsText() {
+        return this.instructionsText;
+    }
+
+    public FaceDetectListener getFaceDetectListener() {
+        return faceDetectListener;
+    }
+
+    public void setFaceDetectListener(FaceDetectListener faceDetectListener) {
+        this.faceDetectListener = faceDetectListener;
+    }
+
+    public interface FaceDetectListener extends Serializable {
+        void overlayDraw(Canvas overlay, Face face, Image faceImage);
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
@@ -1,6 +1,11 @@
 package org.researchstack.backbone.step.active;
 
 import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.media.Image;
+
+import com.google.mlkit.vision.face.Face;
 
 import org.researchstack.backbone.ui.step.layout.ActiveSelfieCaptureStepLayout;
 
@@ -46,5 +51,6 @@ public class ActiveSelfieCaptureStep extends ActiveStep {
 
     public interface DrawOverlayListener extends Serializable {
         void draw(Canvas overlay);
+        boolean isFaceInPosition(RectF overlay, RectF faceImage, Rect face);
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveSelfieCaptureStep.java
@@ -1,9 +1,6 @@
 package org.researchstack.backbone.step.active;
 
 import android.graphics.Canvas;
-import android.media.Image;
-
-import com.google.mlkit.vision.face.Face;
 
 import org.researchstack.backbone.ui.step.layout.ActiveSelfieCaptureStepLayout;
 
@@ -12,7 +9,8 @@ import java.io.Serializable;
 public class ActiveSelfieCaptureStep extends ActiveStep {
 
     private String instructionsText;
-    private FaceDetectListener faceDetectListener;
+    private DrawOverlayListener drawOverlayListener;
+    private int captureWaitTimeSeconds;
 
     public ActiveSelfieCaptureStep(String identifier, String title, String detailText) {
         super(identifier, title, detailText);
@@ -30,15 +28,23 @@ public class ActiveSelfieCaptureStep extends ActiveStep {
         return this.instructionsText;
     }
 
-    public FaceDetectListener getFaceDetectListener() {
-        return faceDetectListener;
+    public DrawOverlayListener getDrawOverlayListener() {
+        return drawOverlayListener;
     }
 
-    public void setFaceDetectListener(FaceDetectListener faceDetectListener) {
-        this.faceDetectListener = faceDetectListener;
+    public void setDrawOverlayListener(DrawOverlayListener drawOverlayListener) {
+        this.drawOverlayListener = drawOverlayListener;
     }
 
-    public interface FaceDetectListener extends Serializable {
-        void overlayDraw(Canvas overlay, Face face, Image faceImage);
+    public int getCaptureWaitTimeSeconds() {
+        return captureWaitTimeSeconds;
+    }
+
+    public void setCaptureWaitTimeSeconds(int captureWaitTimeSeconds) {
+        this.captureWaitTimeSeconds = captureWaitTimeSeconds;
+    }
+
+    public interface DrawOverlayListener extends Serializable {
+        void draw(Canvas overlay);
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
@@ -69,16 +69,16 @@ public class ActiveAudioCaptureBuilder {
             newRequests.add(request);
         }
 
-        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    R.drawable.ic_baseline_storage_24,
-                    R.string.rsb_permission_write_external_storage_name,
-                    R.string.rsb_permission_write_external_storage_description);
-            request.setIsBlockingPermission(true);
-            request.setIsSystemPermission(true);
-            newRequests.add(request);
-        }
+//        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+//            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+//                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+//                    R.drawable.ic_baseline_storage_24,
+//                    R.string.rsb_permission_write_external_storage_name,
+//                    R.string.rsb_permission_write_external_storage_description);
+//            request.setIsBlockingPermission(true);
+//            request.setIsSystemPermission(true);
+//            newRequests.add(request);
+//        }
 
         if (!newRequests.isEmpty()) {
             PermissionRequestManager.getInstance().setPermissionRequests(newRequests);

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
@@ -1,0 +1,134 @@
+package org.researchstack.backbone.task.builder;
+
+import static org.researchstack.backbone.task.factory.TaskFactory.Constants.Instruction1StepIdentifier;
+
+import android.Manifest;
+import android.content.Context;
+
+import org.researchstack.backbone.PermissionRequestManager;
+import org.researchstack.backbone.R;
+import org.researchstack.backbone.step.InstructionStep;
+import org.researchstack.backbone.step.PermissionsStep;
+import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.task.NavigableOrderedTask;
+import org.researchstack.backbone.task.OrderedTask;
+import org.researchstack.backbone.task.Task;
+import org.researchstack.backbone.task.factory.TaskFactory;
+import org.researchstack.backbone.step.active.ActiveAudioCaptureStep;
+import org.researchstack.backbone.utils.ResUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActiveAudioCaptureBuilder {
+    public static final String AUDIO_RESULTS_STEP_ID = "audioStep";
+
+    private Context context;
+    private String identifier, infoTitle, infoInstructions, captureTitle, captureInstructions;
+    private int durationSeconds;
+
+    public ActiveAudioCaptureBuilder setContext(Context context) {
+        this.context = context;
+        return this;
+    }
+
+    public ActiveAudioCaptureBuilder setIdentifier(String identifier) {
+        this.identifier = identifier;
+        return this;
+    }
+
+    public ActiveAudioCaptureBuilder setInfoText(String infoTitle, String infoInstructions) {
+        this.infoTitle = infoTitle;
+        this.infoInstructions = infoInstructions;
+        return this;
+    }
+
+    public ActiveAudioCaptureBuilder setCaptureText(String captureTitle, String captureInstructions) {
+        this.captureTitle = captureTitle;
+        this.captureInstructions = captureInstructions;
+        return this;
+    }
+
+    public ActiveAudioCaptureBuilder setDurationSeconds(int durationSeconds) {
+        this.durationSeconds = durationSeconds;
+        return this;
+    }
+
+    public Task build() {
+        List<Step> steps = new ArrayList<>();
+
+        List<PermissionRequestManager.PermissionRequest> newRequests = new ArrayList<>();
+        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.RECORD_AUDIO)) {
+            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+                    Manifest.permission.RECORD_AUDIO,
+                    R.drawable.ic_baseline_mic_24,
+                    R.string.permission_record_audio_name,
+                    R.string.permission_record_audio_description);
+            request.setIsBlockingPermission(true);
+            request.setIsSystemPermission(true);
+            newRequests.add(request);
+        }
+
+        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    R.drawable.ic_baseline_storage_24,
+                    R.string.permission_write_external_storage_name,
+                    R.string.permission_write_external_storage_description);
+            request.setIsBlockingPermission(true);
+            request.setIsSystemPermission(true);
+            newRequests.add(request);
+        }
+
+        if (!newRequests.isEmpty()) {
+            PermissionRequestManager.getInstance().setPermissionRequests(newRequests);
+            PermissionsStep step1 = new PermissionsStep("permissionsStep",
+                    context.getString(R.string.permission_permission_check_title),
+                    context.getString(R.string.permission_permission_check_text));
+            steps.add(step1);
+        }
+
+        String step2Title = (infoTitle == null) ? context.getString(R.string.rsb_AUDIO_TASK_TITLE) : infoTitle;
+        InstructionStep step2 = new InstructionStep(Instruction1StepIdentifier, step2Title, infoInstructions);
+        step2.setMoreDetailText(context.getString(R.string.rsb_AUDIO_CALL_TO_ACTION));
+        step2.setImage(ResUtils.Audio.PHONE_SOUND_WAVES);
+        steps.add(step2);
+
+//        AudioRecorderSettings recordingSettings = AudioRecorderSettings.defaultSettings();
+
+//        CountdownStep step3 = new CountdownStep(CountdownStepIdentifier);
+//        step3.setRecorderConfigurationList(Collections.singletonList(new AudioRecorderConfig(
+//                AudioRecorderSettings.defaultSettings(), AudioRecorderIdentifier)));
+//        step3.setText(this.getString(R.string.rsb_AUDIO_LEVEL_CHECK_LABEL));
+//        steps.add(step3);
+//
+//        String tooLoudMessage = this.getString(R.string.rsb_AUDIO_TOO_LOUD_MESSAGE);
+//        AudioTooLoudStep step5 = new AudioTooLoudStep("tooLoudStep", null, tooLoudMessage);
+//        step5.setMoreDetailText(this.getString(R.string.rsb_AUDIO_TOO_LOUD_ACTION_NEXT));
+//        step5.setLoudnessThreshold(0.45);
+//        step5.setAudioStepResultIdentifier(CountdownStepIdentifier);
+//        step5.setNextStepIdentifier(Instruction1StepIdentifier);
+//        steps.add(step5);
+//
+//        AudioStep step6 = new AudioStep("recordAudioStep", null, null);
+//        step6.setTitle("Speak for 10 seconds.");
+//        step6.setRecorderConfigurationList(Collections.singletonList(new AudioRecorderConfig(
+//                recordingSettings, AudioRecorderIdentifier)));
+//        step6.setStepDuration(10);
+//        step6.setShouldContinueOnFinish(true);
+//        steps.add(step6);
+
+        ActiveAudioCaptureStep step3 = new ActiveAudioCaptureStep(
+                AUDIO_RESULTS_STEP_ID,
+                captureTitle,
+                null,
+                durationSeconds);
+        step3.setInstructionsText(captureInstructions);
+        steps.add(step3);
+
+        steps.add(TaskFactory.makeCompletionStep(context));
+
+        OrderedTask task = new NavigableOrderedTask(identifier, steps);
+        return task;
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveAudioCaptureBuilder.java
@@ -62,8 +62,8 @@ public class ActiveAudioCaptureBuilder {
             PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
                     Manifest.permission.RECORD_AUDIO,
                     R.drawable.ic_baseline_mic_24,
-                    R.string.permission_record_audio_name,
-                    R.string.permission_record_audio_description);
+                    R.string.rsb_permission_record_audio_name,
+                    R.string.rsb_permission_record_audio_description);
             request.setIsBlockingPermission(true);
             request.setIsSystemPermission(true);
             newRequests.add(request);
@@ -73,8 +73,8 @@ public class ActiveAudioCaptureBuilder {
             PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     R.drawable.ic_baseline_storage_24,
-                    R.string.permission_write_external_storage_name,
-                    R.string.permission_write_external_storage_description);
+                    R.string.rsb_permission_write_external_storage_name,
+                    R.string.rsb_permission_write_external_storage_description);
             request.setIsBlockingPermission(true);
             request.setIsSystemPermission(true);
             newRequests.add(request);
@@ -83,8 +83,8 @@ public class ActiveAudioCaptureBuilder {
         if (!newRequests.isEmpty()) {
             PermissionRequestManager.getInstance().setPermissionRequests(newRequests);
             PermissionsStep step1 = new PermissionsStep("permissionsStep",
-                    context.getString(R.string.permission_permission_check_title),
-                    context.getString(R.string.permission_permission_check_text));
+                    context.getString(R.string.rsb_permission_permission_check_title),
+                    context.getString(R.string.rsb_permission_permission_check_text));
             steps.add(step1);
         }
 

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
@@ -1,0 +1,100 @@
+package org.researchstack.backbone.task.builder;
+
+import android.Manifest;
+import android.content.Context;
+
+import org.researchstack.backbone.PermissionRequestManager;
+import org.researchstack.backbone.R;
+import org.researchstack.backbone.step.InstructionStep;
+import org.researchstack.backbone.step.PermissionsStep;
+import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.task.OrderedTask;
+import org.researchstack.backbone.task.Task;
+import org.researchstack.backbone.task.factory.TaskFactory;
+import org.researchstack.backbone.step.active.ActiveSelfieCaptureStep;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActiveSelfieCaptureBuilder {
+    public static final String SELFIE_RESULTS_STEP_ID = "selfieStep";
+
+    private Context context;
+    private String identifier, infoTitle, infoInstructions, captureTitle, captureInstructions;
+
+    public ActiveSelfieCaptureBuilder setIdentifier(String identifier) {
+        this.identifier = identifier;
+        return this;
+    }
+
+    public ActiveSelfieCaptureBuilder setContext(Context context) {
+        this.context = context;
+        return this;
+    }
+
+    public ActiveSelfieCaptureBuilder setInfoText(String infoTitle, String infoInstructions) {
+        this.infoTitle = infoTitle;
+        this.infoInstructions = infoInstructions;
+        return this;
+    }
+
+    public ActiveSelfieCaptureBuilder setCaptureText(String captureTitle, String captureInstructions) {
+        this.captureTitle = captureTitle;
+        this.captureInstructions = captureInstructions;
+        return this;
+    }
+
+    public Task build() {
+        List<Step> steps = new ArrayList<>();
+
+        List<PermissionRequestManager.PermissionRequest> newRequests = new ArrayList<>();
+        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.CAMERA)) {
+            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+                    Manifest.permission.CAMERA,
+                    R.drawable.ic_baseline_photo_camera_24,
+                    R.string.permission_camera_name,
+                    R.string.permission_camera_description);
+            request.setIsBlockingPermission(true);
+            request.setIsSystemPermission(true);
+            newRequests.add(request);
+        }
+
+        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    R.drawable.ic_baseline_storage_24,
+                    R.string.permission_write_external_storage_name,
+                    R.string.permission_write_external_storage_description);
+            request.setIsBlockingPermission(true);
+            request.setIsSystemPermission(true);
+            newRequests.add(request);
+        }
+
+        if (!newRequests.isEmpty()) {
+            PermissionRequestManager.getInstance().setPermissionRequests(newRequests);
+            PermissionsStep step1 = new PermissionsStep("permissionsStep",
+                    context.getString(R.string.permission_permission_check_title),
+                    context.getString(R.string.permission_permission_check_text));
+            steps.add(step1);
+        }
+
+        InstructionStep step2 = new InstructionStep("intro",
+                infoTitle,
+                infoInstructions);
+        step2.setStepTitle(R.string.active_selfie_capture_test_title);
+        step2.setImage("rsb_tremor_in_hand");
+        steps.add(step2);
+
+        ActiveSelfieCaptureStep step3 = new ActiveSelfieCaptureStep(
+                SELFIE_RESULTS_STEP_ID,
+                captureTitle,
+                null);
+        step3.setInstructionsText(captureInstructions);
+        steps.add(step3);
+
+        steps.add(TaskFactory.makeCompletionStep(context));
+
+        OrderedTask task = new OrderedTask(identifier, steps);
+        return task;
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
@@ -52,8 +52,8 @@ public class ActiveSelfieCaptureBuilder {
             PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
                     Manifest.permission.CAMERA,
                     R.drawable.ic_baseline_photo_camera_24,
-                    R.string.permission_camera_name,
-                    R.string.permission_camera_description);
+                    R.string.rsb_permission_camera_name,
+                    R.string.rsb_permission_camera_description);
             request.setIsBlockingPermission(true);
             request.setIsSystemPermission(true);
             newRequests.add(request);
@@ -63,8 +63,8 @@ public class ActiveSelfieCaptureBuilder {
             PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     R.drawable.ic_baseline_storage_24,
-                    R.string.permission_write_external_storage_name,
-                    R.string.permission_write_external_storage_description);
+                    R.string.rsb_permission_write_external_storage_name,
+                    R.string.rsb_permission_write_external_storage_description);
             request.setIsBlockingPermission(true);
             request.setIsSystemPermission(true);
             newRequests.add(request);
@@ -73,15 +73,15 @@ public class ActiveSelfieCaptureBuilder {
         if (!newRequests.isEmpty()) {
             PermissionRequestManager.getInstance().setPermissionRequests(newRequests);
             PermissionsStep step1 = new PermissionsStep("permissionsStep",
-                    context.getString(R.string.permission_permission_check_title),
-                    context.getString(R.string.permission_permission_check_text));
+                    context.getString(R.string.rsb_permission_permission_check_title),
+                    context.getString(R.string.rsb_permission_permission_check_text));
             steps.add(step1);
         }
 
         InstructionStep step2 = new InstructionStep("intro",
                 infoTitle,
                 infoInstructions);
-        step2.setStepTitle(R.string.active_selfie_capture_test_title);
+        step2.setStepTitle(R.string.rsb_active_selfie_capture_test_title);
         step2.setImage("rsb_tremor_in_hand");
         steps.add(step2);
 

--- a/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/builder/ActiveSelfieCaptureBuilder.java
@@ -21,6 +21,8 @@ public class ActiveSelfieCaptureBuilder {
 
     private Context context;
     private String identifier, infoTitle, infoInstructions, captureTitle, captureInstructions;
+    private ActiveSelfieCaptureStep.DrawOverlayListener drawOverlayListener;
+    private int waitTimeSeconds;
 
     public ActiveSelfieCaptureBuilder setIdentifier(String identifier) {
         this.identifier = identifier;
@@ -44,6 +46,16 @@ public class ActiveSelfieCaptureBuilder {
         return this;
     }
 
+    public ActiveSelfieCaptureBuilder setDrawOverlayListener(ActiveSelfieCaptureStep.DrawOverlayListener drawOverlayListener) {
+        this.drawOverlayListener = drawOverlayListener;
+        return this;
+    }
+
+    public ActiveSelfieCaptureBuilder setWaitTimeSeconds(int waitTimeSeconds) {
+        this.waitTimeSeconds = waitTimeSeconds;
+        return this;
+    }
+
     public Task build() {
         List<Step> steps = new ArrayList<>();
 
@@ -59,16 +71,16 @@ public class ActiveSelfieCaptureBuilder {
             newRequests.add(request);
         }
 
-        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    R.drawable.ic_baseline_storage_24,
-                    R.string.rsb_permission_write_external_storage_name,
-                    R.string.rsb_permission_write_external_storage_description);
-            request.setIsBlockingPermission(true);
-            request.setIsSystemPermission(true);
-            newRequests.add(request);
-        }
+//        if (!PermissionRequestManager.getInstance().hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+//            PermissionRequestManager.PermissionRequest request = new PermissionRequestManager.PermissionRequest(
+//                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+//                    R.drawable.ic_baseline_storage_24,
+//                    R.string.rsb_permission_write_external_storage_name,
+//                    R.string.rsb_permission_write_external_storage_description);
+//            request.setIsBlockingPermission(true);
+//            request.setIsSystemPermission(true);
+//            newRequests.add(request);
+//        }
 
         if (!newRequests.isEmpty()) {
             PermissionRequestManager.getInstance().setPermissionRequests(newRequests);
@@ -90,6 +102,9 @@ public class ActiveSelfieCaptureBuilder {
                 captureTitle,
                 null);
         step3.setInstructionsText(captureInstructions);
+        step3.setCaptureWaitTimeSeconds(waitTimeSeconds);
+        if (drawOverlayListener != null)
+            step3.setDrawOverlayListener(drawOverlayListener);
         steps.add(step3);
 
         steps.add(TaskFactory.makeCompletionStep(context));

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveAudioCaptureFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveAudioCaptureFactory.java
@@ -1,0 +1,25 @@
+package org.researchstack.backbone.task.factory;
+
+import android.content.Context;
+
+import org.researchstack.backbone.task.Task;
+import org.researchstack.backbone.task.builder.ActiveAudioCaptureBuilder;
+
+public class ActiveAudioCaptureFactory {
+
+    public static Task audioCaptureTask(String identifier,
+                                        Context context,
+                                        String infoText,
+                                        String infoInstructions,
+                                        String captureText,
+                                        String captureInstructions,
+                                        int durationSeconds) {
+        return new ActiveAudioCaptureBuilder()
+                .setIdentifier(identifier)
+                .setContext(context)
+                .setInfoText(infoText, infoInstructions)
+                .setCaptureText(captureText, captureInstructions)
+                .setDurationSeconds(durationSeconds)
+                .build();
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
@@ -12,12 +12,14 @@ public class ActiveSelfieCaptureFactory {
                                          String infoText,
                                          String infoInstructions,
                                          String captureText,
-                                         String captureInstructions) {
+                                         String captureInstructions,
+                                         int waitTimeSeconds) {
         return new ActiveSelfieCaptureBuilder()
                 .setIdentifier(identifier)
                 .setContext(context)
                 .setInfoText(infoText, infoInstructions)
                 .setCaptureText(captureText, captureInstructions)
+                .setWaitTimeSeconds(waitTimeSeconds)
                 .build();
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
@@ -1,0 +1,23 @@
+package org.researchstack.backbone.task.factory;
+
+import android.content.Context;
+
+import org.researchstack.backbone.task.Task;
+import org.researchstack.backbone.task.builder.ActiveSelfieCaptureBuilder;
+
+public class ActiveSelfieCaptureFactory {
+
+    public static Task selfieCaptureTask(String identifier,
+                                         Context context,
+                                         String infoText,
+                                         String infoInstructions,
+                                         String captureText,
+                                         String captureInstructions) {
+        return new ActiveSelfieCaptureBuilder()
+                .setIdentifier(identifier)
+                .setContext(context)
+                .setInfoText(infoText, infoInstructions)
+                .setCaptureText(captureText, captureInstructions)
+                .build();
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
@@ -1,7 +1,15 @@
 package org.researchstack.backbone.task.factory;
 
 import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.PointF;
+import android.graphics.Rect;
+import android.graphics.RectF;
 
+import org.researchstack.backbone.step.active.ActiveSelfieCaptureStep;
 import org.researchstack.backbone.task.Task;
 import org.researchstack.backbone.task.builder.ActiveSelfieCaptureBuilder;
 
@@ -20,6 +28,104 @@ public class ActiveSelfieCaptureFactory {
                 .setInfoText(infoText, infoInstructions)
                 .setCaptureText(captureText, captureInstructions)
                 .setWaitTimeSeconds(waitTimeSeconds)
+                .setDrawOverlayListener(new DefaultFaceOverlay())
                 .build();
+    }
+
+    public static Task selfieCaptureTask(String identifier,
+                                         Context context,
+                                         String infoText,
+                                         String infoInstructions,
+                                         String captureText,
+                                         String captureInstructions,
+                                         int waitTimeSeconds,
+                                         ActiveSelfieCaptureStep.DrawOverlayListener listener) {
+        return new ActiveSelfieCaptureBuilder()
+                .setIdentifier(identifier)
+                .setContext(context)
+                .setInfoText(infoText, infoInstructions)
+                .setCaptureText(captureText, captureInstructions)
+                .setWaitTimeSeconds(waitTimeSeconds)
+                .setDrawOverlayListener(listener)
+                .build();
+    }
+
+    public static class DefaultFaceOverlay implements ActiveSelfieCaptureStep.DrawOverlayListener {
+
+        @Override
+        public void draw(Canvas overlay) {
+            float vWidth = overlay.getWidth();
+            float vHeight = overlay.getHeight();
+            RectF vMaxBounds = getViewportBoundingBox(vWidth, vHeight, new RectF(20f, 10f, 180f, 190f));
+            RectF all = new RectF(0, 0, vWidth, vHeight);
+
+            Paint fill = new Paint();
+            fill.setStyle(Paint.Style.FILL);
+            fill.setColor(Color.BLACK);
+            fill.setAlpha(100);
+
+            Path oval = new Path();
+            oval.addOval(vMaxBounds, Path.Direction.CW);
+
+            overlay.clipOutPath(oval);
+            overlay.drawRect(all, fill);
+
+            Paint stroke = new Paint();
+            stroke.setStyle(Paint.Style.STROKE);
+            stroke.setColor(Color.WHITE);
+            stroke.setStrokeWidth(20);
+            overlay.drawPath(oval, stroke);
+        }
+
+        @Override
+        public boolean isFaceInPosition(RectF overlay, RectF faceImage, Rect face) {
+            float vWidth = overlay.width();
+            float vHeight = overlay.height();
+            float wWidth = faceImage.width();
+            float wHeight = faceImage.height();
+
+            // flip the left and right coordinates for the face bounds
+            PointF t1 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.right, face.top)));
+            PointF t2 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.left, face.bottom)));
+            RectF vFaceBounds = new RectF(t1.x, t1.y, t2.x, t2.y);
+            RectF vMinBounds = getViewportBoundingBox(vWidth, vHeight, new RectF(50f, 50f, 150f, 150f));
+
+            return vFaceBounds.contains(vMinBounds);
+        }
+
+        private PointF translate(float width, float height, Rect bounds, PointF p) {
+            float xBuffer = (width - bounds.width()) / 2f;
+            float xDelta = Math.abs(p.x - bounds.left);
+
+            float yBuffer = (height - bounds.height()) / 2f;
+            float yDelta = Math.abs(p.y - bounds.top);
+
+            PointF out = new PointF();
+            out.x = width - (xBuffer + xDelta);
+            out.y = yBuffer + yDelta;
+            return out;
+        }
+
+        private PointF transform(float wWidth, float wHeight, float vWidth, float vHeight, PointF wPoint) {
+            float sX = vWidth / wWidth;
+            float sY = vHeight / wHeight;
+            PointF out = new PointF();
+            out.x = wPoint.x * sX;
+            out.y = wPoint.y * sY;
+            return out;
+        }
+
+        private RectF getViewportBoundingBox(float vWidth, float vHeight, RectF box) {
+            float wWidth = 200f;
+            float wHeight = 200f;
+            float sX = vWidth / wWidth;
+            float sY = vHeight / wHeight;
+            RectF out = new RectF();
+            out.left = box.left * sX;
+            out.top = box.top * sY;
+            out.right = box.right * sX;
+            out.bottom = box.bottom * sY;
+            return out;
+        }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/ActiveSelfieCaptureFactory.java
@@ -79,18 +79,19 @@ public class ActiveSelfieCaptureFactory {
 
         @Override
         public boolean isFaceInPosition(RectF overlay, RectF faceImage, Rect face) {
-            float vWidth = overlay.width();
-            float vHeight = overlay.height();
-            float wWidth = faceImage.width();
-            float wHeight = faceImage.height();
-
-            // flip the left and right coordinates for the face bounds
-            PointF t1 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.right, face.top)));
-            PointF t2 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.left, face.bottom)));
-            RectF vFaceBounds = new RectF(t1.x, t1.y, t2.x, t2.y);
-            RectF vMinBounds = getViewportBoundingBox(vWidth, vHeight, new RectF(50f, 50f, 150f, 150f));
-
-            return vFaceBounds.contains(vMinBounds);
+//            float vWidth = overlay.width();
+//            float vHeight = overlay.height();
+//            float wWidth = faceImage.width();
+//            float wHeight = faceImage.height();
+//
+//            // flip the left and right coordinates for the face bounds
+//            PointF t1 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.right, face.top)));
+//            PointF t2 = transform(wWidth, wHeight, vWidth, vHeight, translate(wWidth, wHeight, face, new PointF(face.left, face.bottom)));
+//            RectF vFaceBounds = new RectF(t1.x, t1.y, t2.x, t2.y);
+//            RectF vMinBounds = getViewportBoundingBox(vWidth, vHeight, new RectF(50f, 50f, 150f, 150f));
+//
+//            return vFaceBounds.contains(vMinBounds);
+            return true;
         }
 
         private PointF translate(float width, float height, Rect bounds, PointF p) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
@@ -1,0 +1,309 @@
+package org.researchstack.backbone.ui.step.layout;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.media.MediaRecorder;
+import android.media.MicrophoneDirection;
+import android.os.Build;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import org.researchstack.backbone.R;
+import org.researchstack.backbone.result.StepResult;
+import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.step.active.ActiveAudioCaptureStep;
+import org.researchstack.backbone.ui.ViewTaskActivity;
+import org.researchstack.backbone.ui.callbacks.StepCallbacks;
+import org.researchstack.backbone.ui.step.layout.ActiveStepLayout;
+import org.researchstack.backbone.ui.views.SubmitBar;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
+
+    private static final String BUTTON_RECORD = "Record";
+    private static final String BUTTON_STOP = "Stop";
+    private static final String BUTTON_RESET = "Reset";
+
+    private Step step;
+    private StepCallbacks callbacks;
+    private MediaRecorder recorder;
+    private ScheduledExecutorService executorService;
+    private ScheduledFuture<?> stopwatchFuture, autoStopFuture;
+    private File outputFile;
+
+    private AtomicBoolean isStoppingRecording;
+
+    public ActiveAudioCaptureStepLayout(Context context) {
+        super(context);
+    }
+
+    @Override
+    public int getContentResourceId() {
+        return R.layout.active_audio_capture_step;
+    }
+
+    @Override
+    public void initialize(Step step, StepResult stepResult) {
+        super.initialize(step, stepResult);
+        this.step = step;
+        this.recorder = null;
+        this.isStoppingRecording = new AtomicBoolean(false);
+        initializeView(stepResult);
+    }
+
+    @Override
+    public View getLayout() {
+        return this;
+    }
+
+    public void initializeView(StepResult stepResult) {
+        TextView title = (TextView)this.findViewById(R.id.audioCaptureTitle);
+        title.setText(this.step.getTitle());
+
+        TextView instructions = (TextView)this.findViewById(R.id.audioCaptureDescription);
+        instructions.setText(((ActiveAudioCaptureStep)this.step).getInstructionsText());
+
+        TextView time = (TextView)this.findViewById(R.id.audioCaptureTime);
+
+        FloatingActionButton captureButton = (FloatingActionButton)this.findViewById(R.id.audioCaptureButton);
+        captureButton.setOnClickListener(clickView -> {
+            ContextThemeWrapper wrapper = (ContextThemeWrapper)clickView.getContext();
+            Activity activity = (Activity)wrapper.getBaseContext();
+            TextView captureButtonText = (TextView)activity.findViewById(R.id.audioCaptureButtonText);
+            if (isRecording(captureButtonText)) {
+                captureButtonText.setText(BUTTON_RESET);
+                stopRecording();
+            } else if (isReadyToRecord(captureButtonText)) {
+                if (recorder != null)
+                    throw new RuntimeException("MediaRecorder currently in use, cannot reinitialize");
+                captureButtonText.setText(BUTTON_STOP);
+                startRecording(activity);
+            } else if (isReadyToReset(captureButtonText)) {
+                resetRecording(activity, captureButtonText);
+            }
+        });
+
+        TextView captureButtonText = (TextView)this.findViewById(R.id.audioCaptureButtonText);
+        if (stepResult == null) {
+            time.setText(buildStartTime());
+            time.setTextColor(ContextCompat.getColor(getContext(), R.color.black));
+            captureButtonText.setText(BUTTON_RECORD);
+        } else {
+            time.setText(((AudioCaptureResults)stepResult.getResult()).lastRecordedTime);
+            captureButtonText.setText(BUTTON_RESET);
+            outputFile = new File(((AudioCaptureResults)stepResult.getResult()).outputFileName);
+        }
+
+        SubmitBar submitBar = (SubmitBar)this.findViewById(R.id.rsb_submit_bar);
+        submitBar.setPositiveTitle(R.string.rsb_BUTTON_NEXT);
+        submitBar.getNegativeActionView().setVisibility(View.INVISIBLE);
+        submitBar.setPositiveAction(result -> {
+            ViewTaskActivity activity = (ViewTaskActivity)this.getContext();
+            if (isReadyToReset(captureButtonText) && outputFile != null && outputFile.exists()) {
+                activity.onSaveStep(StepCallbacks.ACTION_NEXT, step, buildStepResult());
+                return;
+            }
+            AlertDialog alert = new AlertDialog.Builder(activity).create();
+            alert.setTitle("Error");
+            alert.setMessage("Must record audio to continue.");
+            alert.setButton(AlertDialog.BUTTON_NEUTRAL, "OK", (dialog, witch) -> dialog.dismiss());
+            alert.show();
+        });
+    }
+
+    private String buildStartTime() {
+        int durationSeconds = ((ActiveAudioCaptureStep)step).getStepDuration();
+        return "00:" + durationSeconds + ".0";
+    }
+
+    private StepResult buildStepResult() {
+        try {
+            AudioCaptureResults r = new AudioCaptureResults();
+            r.outputFileName = outputFile.getAbsolutePath();
+            TextView time = (TextView) this.findViewById(R.id.audioCaptureTime);
+            r.lastRecordedTime = time.getText().toString();
+            StepResult result = new StepResult(step);
+            result.setResult(r);
+            return result;
+        } catch (Exception e) {
+            // catch this exception here and return null so the app doesn't crash
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isBackEventConsumed() {
+        StepResult result = null;
+        TextView captureButtonText = (TextView)this.findViewById(R.id.audioCaptureButtonText);
+        if (isReadyToReset(captureButtonText) && outputFile != null && outputFile.exists())
+            result = buildStepResult();
+        this.callbacks.onSaveStep(StepCallbacks.ACTION_PREV, step, result);
+        return false;
+    }
+
+    @Override
+    public void setCallbacks(StepCallbacks callbacks) {
+        this.callbacks = callbacks;
+    }
+
+    private boolean isRecording(TextView buttonText) {
+        return BUTTON_STOP.equals(buttonText.getText());
+    }
+
+    private boolean isReadyToRecord(TextView buttonText) {
+        return BUTTON_RECORD.equals(buttonText.getText());
+    }
+
+    private boolean isReadyToReset(TextView buttonText) {
+        return BUTTON_RESET.equals(buttonText.getText());
+    }
+
+    private void resetRecording(Activity activity, TextView captureButtonText) {
+        AlertDialog alert = new AlertDialog.Builder(activity).create();
+        alert.setTitle("Reset Audio");
+        alert.setMessage("Are you sure?");
+        alert.setButton(AlertDialog.BUTTON_POSITIVE, "Yes", (dialog, witch) -> {
+            captureButtonText.setText(BUTTON_RECORD);
+            TextView time = (TextView)activity.findViewById(R.id.audioCaptureTime);
+            time.setText(buildStartTime());
+            time.setTextColor(ContextCompat.getColor(getContext(), R.color.black));
+            outputFile.delete();
+            dialog.dismiss();
+        });
+        alert.setButton(AlertDialog.BUTTON_NEGATIVE, "No", (dialog, witch) -> dialog.dismiss());
+        alert.show();
+    }
+
+    private void startRecording(Activity activity) {
+        try {
+            executorService = Executors.newSingleThreadScheduledExecutor();
+            int duration = ((ActiveAudioCaptureStep)step).getStepDuration();
+            stopwatchFuture = executorService.scheduleWithFixedDelay(new UpdateTimeTask(activity, duration), 0, 100, TimeUnit.MILLISECONDS);
+
+            File filesDir = activity.getFilesDir();
+            filesDir.mkdir();
+            outputFile = Paths.get(filesDir.toURI()).resolve(UUID.randomUUID().toString() + ".aac").toFile();
+
+            recorder = new MediaRecorder();
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+            recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS);
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
+            recorder.setOutputFile(outputFile);
+            recorder.setAudioChannels(1);
+            recorder.setAudioSamplingRate(96000); // highest supported for AAC
+            recorder.setAudioEncodingBitRate(256);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                recorder.setPreferredMicrophoneDirection(MicrophoneDirection.MIC_DIRECTION_TOWARDS_USER);
+            }
+            recorder.prepare();
+            recorder.start();
+
+            int durationMS = (duration * 1000) + 200; // add some small buffer to the end
+            autoStopFuture = executorService.schedule(new AutoStopTask(activity), durationMS, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void stopRecording() {
+        if (isStoppingRecording.getAndSet(true))
+            return;
+
+        try {
+            if (recorder != null) {
+                recorder.stop();
+                recorder.release();
+                recorder = null;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (stopwatchFuture != null) {
+                stopwatchFuture.cancel(true);
+                stopwatchFuture = null;
+            }
+
+            if (autoStopFuture != null) {
+                autoStopFuture.cancel(true);
+                autoStopFuture = null;
+            }
+
+            if (executorService != null) {
+                executorService.shutdownNow();
+                executorService = null;
+            }
+        }
+
+        isStoppingRecording.set(false);
+    }
+
+    private class UpdateTimeTask implements Runnable {
+        private final SimpleDateFormat df;
+        private final Activity activity;
+        private final long startTime;
+        private final int durationMS;
+
+        public UpdateTimeTask(Activity activity, int duration) {
+            this.activity = activity;
+            this.startTime = System.currentTimeMillis();
+            this.durationMS = duration * 1000;
+            this.df = new SimpleDateFormat("mm:ss.S");
+        }
+
+        @Override
+        public void run() {
+             activity.runOnUiThread(() -> {
+                TextView timeView = (TextView)activity.findViewById(R.id.audioCaptureTime);
+                if (timeView == null)
+                    return;
+                 long remaining = durationMS - (System.currentTimeMillis() - startTime);
+                 if (remaining < 0)
+                     remaining = 0;
+                 if (remaining <= 3000) {
+                     timeView.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
+                 }
+                 timeView.setText(df.format(remaining));
+            });
+        }
+    }
+
+    private class AutoStopTask implements Runnable {
+        private final Activity activity;
+
+        public AutoStopTask(Activity activity) {
+            this.activity = activity;
+        }
+
+        @Override
+        public void run() {
+            activity.runOnUiThread(() -> {
+                TextView captureButtonText = (TextView)activity.findViewById(R.id.audioCaptureButtonText);
+                if (captureButtonText != null)
+                    captureButtonText.setText(BUTTON_RESET);
+            });
+            stopRecording();
+        }
+    }
+
+    public static class AudioCaptureResults implements Serializable {
+        public String outputFileName;
+        public String lastRecordedTime;
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
@@ -206,7 +206,7 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
             recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS);
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             recorder.setOutputFile(outputFile);
-            recorder.setAudioChannels(1);
+            recorder.setAudioChannels(2);
             recorder.setAudioSamplingRate(96000); // highest supported for AAC
             recorder.setAudioEncodingBitRate(256);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
@@ -129,7 +129,10 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
 
     private String buildStartTime() {
         int durationSeconds = ((ActiveAudioCaptureStep)step).getStepDuration();
-        return "00:" + durationSeconds + ".0";
+        long current = System.currentTimeMillis();
+        long time = current - (current - (durationSeconds * 1000));
+        SimpleDateFormat df = new SimpleDateFormat("mm:ss.S");
+        return df.format(time);
     }
 
     private StepResult buildStepResult() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
@@ -102,7 +102,7 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
         TextView captureButtonText = (TextView)this.findViewById(R.id.audioCaptureButtonText);
         if (stepResult == null) {
             time.setText(buildStartTime());
-            time.setTextColor(ContextCompat.getColor(getContext(), R.color.black));
+            time.setTextColor(ContextCompat.getColor(getContext(), R.color.rsb_black));
             captureButtonText.setText(BUTTON_RECORD);
         } else {
             time.setText(((AudioCaptureResults)stepResult.getResult()).lastRecordedTime);
@@ -183,7 +183,7 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
             captureButtonText.setText(BUTTON_RECORD);
             TextView time = (TextView)activity.findViewById(R.id.audioCaptureTime);
             time.setText(buildStartTime());
-            time.setTextColor(ContextCompat.getColor(getContext(), R.color.black));
+            time.setTextColor(ContextCompat.getColor(getContext(), R.color.rsb_black));
             outputFile.delete();
             dialog.dismiss();
         });
@@ -277,7 +277,7 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
                  if (remaining < 0)
                      remaining = 0;
                  if (remaining <= 3000) {
-                     timeView.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
+                     timeView.setTextColor(ContextCompat.getColor(getContext(), R.color.rsb_red));
                  }
                  timeView.setText(df.format(remaining));
             });

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveAudioCaptureStepLayout.java
@@ -206,9 +206,9 @@ public class ActiveAudioCaptureStepLayout extends ActiveStepLayout {
             recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS);
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             recorder.setOutputFile(outputFile);
-            recorder.setAudioChannels(2);
+            recorder.setAudioChannels(1);
             recorder.setAudioSamplingRate(96000); // highest supported for AAC
-            recorder.setAudioEncodingBitRate(256);
+            recorder.setAudioEncodingBitRate(512000);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 recorder.setPreferredMicrophoneDirection(MicrophoneDirection.MIC_DIRECTION_TOWARDS_USER);
             }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveSelfieCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveSelfieCaptureStepLayout.java
@@ -1,0 +1,271 @@
+package org.researchstack.backbone.ui.step.layout;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.media.Image;
+import android.net.Uri;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.camera.core.Camera;
+import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageAnalysis;
+import androidx.camera.core.ImageCapture;
+import androidx.camera.core.ImageCaptureException;
+import androidx.camera.core.ImageProxy;
+import androidx.camera.core.Preview;
+import androidx.camera.lifecycle.ProcessCameraProvider;
+import androidx.camera.view.PreviewView;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.Observer;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.mlkit.vision.common.InputImage;
+import com.google.mlkit.vision.face.Face;
+import com.google.mlkit.vision.face.FaceDetection;
+import com.google.mlkit.vision.face.FaceDetector;
+
+import org.researchstack.backbone.R;
+import org.researchstack.backbone.result.StepResult;
+import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.step.active.ActiveSelfieCaptureStep;
+import org.researchstack.backbone.ui.ViewTaskActivity;
+import org.researchstack.backbone.ui.callbacks.StepCallbacks;
+import org.researchstack.backbone.ui.step.layout.ActiveStepLayout;
+import org.researchstack.backbone.ui.views.SubmitBar;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+public class ActiveSelfieCaptureStepLayout extends ActiveStepLayout {
+
+    private Step step;
+    private StepCallbacks callbacks;
+    private File outputFile;
+    private ImageCapture capture;
+    private Camera camera;
+    private LinearLayout captureLayout, reviewLayout;
+
+    public ActiveSelfieCaptureStepLayout(Context context) {
+        super(context);
+    }
+
+    @Override
+    public int getContentResourceId() {
+        return R.layout.active_selfie_capture_step;
+    }
+
+    @Override
+    public void initialize(Step step, StepResult stepResult) {
+        super.initialize(step, stepResult);
+        this.step = step;
+        this.camera = null;
+        initializeView(stepResult);
+    }
+
+    @Override
+    public View getLayout() {
+        return this;
+    }
+
+    public void initializeView(StepResult stepResult) {
+        ViewTaskActivity activity = (ViewTaskActivity)this.getContext();
+
+        captureLayout = (LinearLayout)this.findViewById(R.id.selfieCaptureLayout);
+        reviewLayout = (LinearLayout)this.findViewById(R.id.selfieReviewLayout);
+
+        TextView title = (TextView)this.findViewById(R.id.selfieCaptureTitle);
+        title.setText(this.step.getTitle());
+
+        TextView instructions = (TextView)this.findViewById(R.id.selfieCaptureDescription);
+        instructions.setText(((ActiveSelfieCaptureStep)this.step).getInstructionsText());
+
+        FloatingActionButton captureButton = (FloatingActionButton)this.findViewById(R.id.selfieCaptureButton);
+        captureButton.setOnClickListener(new TakePictureButtonClickListener());
+
+        FloatingActionButton resetButton = (FloatingActionButton)this.findViewById(R.id.selfieResetButton);
+        resetButton.setOnClickListener(v -> {
+            if (outputFile != null)
+                outputFile.delete();
+            setCaptureMode();
+        });
+
+        FloatingActionButton submitButton = (FloatingActionButton)this.findViewById(R.id.selfieSubmitButton);
+        submitButton.setOnClickListener(v -> {
+            if (outputFile != null && outputFile.exists())
+                activity.onSaveStep(StepCallbacks.ACTION_NEXT, step, buildStepResult());
+        });
+
+        if (stepResult != null)
+            outputFile = new File(((ActiveSelfieCaptureResults)stepResult.getResult()).outputFileName);
+
+        SubmitBar submitBar = (SubmitBar)this.findViewById(R.id.rsb_submit_bar);
+        submitBar.setVisibility(View.GONE);
+
+        PreviewView previewView = (PreviewView)findViewById(R.id.camera_preview);
+        ImageView overlay = (ImageView)findViewById(R.id.camera_preview_overlay);
+        Preview preview = new Preview.Builder().build();
+        preview.setSurfaceProvider(previewView.getSurfaceProvider());
+        ImageAnalysis imageAnalysis = new ImageAnalysis.Builder().build();
+        capture = new ImageCapture.Builder().build();
+        FaceDetector faceDetector = FaceDetection.getClient();
+
+        final ActiveSelfieCaptureStep.FaceDetectListener faceDetectListener = ((ActiveSelfieCaptureStep)step).getFaceDetectListener();
+
+        ListenableFuture<ProcessCameraProvider> future = ProcessCameraProvider.getInstance(activity);
+        future.addListener(() -> {
+            try {
+                ProcessCameraProvider provider = future.get();
+                provider.unbindAll();
+
+                previewView.getPreviewStreamState().observe(activity, new Observer<PreviewView.StreamState>()
+                {
+                    @Override
+                    public void onChanged(PreviewView.StreamState state) {
+                        if (state != PreviewView.StreamState.STREAMING)
+                            return;
+                        imageAnalysis.setAnalyzer(ContextCompat.getMainExecutor(activity), new ImageAnalysis.Analyzer() {
+                            @Override
+                            @androidx.camera.core.ExperimentalGetImage
+                            public void analyze(@NonNull ImageProxy proxy) {
+                                final Image faceImage = proxy.getImage();
+                                if (faceImage == null) {
+                                    proxy.close();
+                                    return;
+                                }
+
+                                if (faceDetectListener != null) {
+                                    InputImage input = InputImage.fromMediaImage(faceImage, proxy.getImageInfo().getRotationDegrees());
+                                    faceDetector.process(input).addOnSuccessListener(new OnSuccessListener<List<Face>>() {
+                                        @Override
+                                        public void onSuccess(@NonNull List<Face> faces) {
+                                            try {
+                                                if (faces.isEmpty()) {
+                                                    activity.runOnUiThread(() -> overlay.setImageBitmap(Bitmap.createBitmap(
+                                                            previewView.getBitmap().getWidth(),
+                                                            previewView.getBitmap().getHeight(),
+                                                            Bitmap.Config.ARGB_8888)));
+                                                    return;
+                                                }
+
+                                                Bitmap overlayImage = Bitmap.createBitmap(
+                                                        previewView.getBitmap().getWidth(),
+                                                        previewView.getBitmap().getHeight(),
+                                                        Bitmap.Config.ARGB_8888);
+                                                Canvas canvas = new Canvas(overlayImage);
+                                                Face face = faces.iterator().next();
+                                                faceDetectListener.overlayDraw(canvas, face, faceImage);
+                                                activity.runOnUiThread(() -> overlay.setImageBitmap(overlayImage));
+                                            } catch (Exception e) {
+                                                e.printStackTrace();
+                                            } finally {
+                                                proxy.close();
+                                            }
+                                        }
+                                    }).addOnFailureListener(new OnFailureListener() {
+
+                                        @Override
+                                        public void onFailure(@NonNull Exception e) {
+                                            e.printStackTrace();
+                                            proxy.close();
+                                        }
+                                    });
+                                }
+                            }
+                        });
+
+                    }
+                });
+                camera = provider.bindToLifecycle(activity, CameraSelector.DEFAULT_FRONT_CAMERA, preview, imageAnalysis, capture);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }, ContextCompat.getMainExecutor(activity));
+    }
+
+    private void setCaptureMode() {
+        captureLayout.setVisibility(View.VISIBLE);
+        reviewLayout.setVisibility(View.GONE);
+    }
+
+    private void setReviewMode() {
+        captureLayout.setVisibility(View.GONE);
+        reviewLayout.setVisibility(View.VISIBLE);
+
+        if (outputFile != null) {
+            ImageView thumbnail = (ImageView) this.findViewById(R.id.selfieDisplayThumbnail);
+            thumbnail.setImageURI(Uri.fromFile(outputFile));
+        }
+    }
+
+    private StepResult buildStepResult() {
+        try {
+            ActiveSelfieCaptureResults r = new ActiveSelfieCaptureResults();
+            r.outputFileName = outputFile.getAbsolutePath();
+            StepResult result = new StepResult(step);
+            result.setResult(r);
+            return result;
+        } catch (Exception e) {
+            // catch this exception here and return null so the app doesn't crash
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isBackEventConsumed() {
+        StepResult result = null;
+        if (outputFile != null && outputFile.exists())
+            result = buildStepResult();
+        this.callbacks.onSaveStep(StepCallbacks.ACTION_PREV, step, result);
+        return false;
+    }
+
+    @Override
+    public void setCallbacks(StepCallbacks callbacks) {
+        this.callbacks = callbacks;
+    }
+
+    private class TakePictureButtonClickListener implements OnClickListener {
+        @Override
+        public void onClick(View clickView) {
+            FloatingActionButton button = (FloatingActionButton)clickView;
+            ContextThemeWrapper wrapper = (ContextThemeWrapper)button.getContext();
+            Context context = wrapper.getApplicationContext();
+            try {
+                File filesDir = context.getFilesDir();
+                filesDir.mkdir();
+                outputFile = Paths.get(filesDir.toURI()).resolve(UUID.randomUUID().toString() + ".jpg").toFile();
+                ImageCapture.OutputFileOptions options = new ImageCapture.OutputFileOptions.Builder(outputFile).build();
+                capture.takePicture(options, ContextCompat.getMainExecutor(context), new ImageCapture.OnImageSavedCallback() {
+                    @Override
+                    public void onImageSaved(@NonNull ImageCapture.OutputFileResults results) {
+                        setReviewMode();
+                    }
+
+                    @Override
+                    public void onError(@NonNull ImageCaptureException e) {
+                        e.printStackTrace();
+                    }
+                });
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static class ActiveSelfieCaptureResults implements Serializable {
+        public String outputFileName;
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveSelfieCaptureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveSelfieCaptureStepLayout.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.RectF;
 import android.media.Image;
 import android.net.Uri;
 import android.view.View;
@@ -194,8 +195,16 @@ public class ActiveSelfieCaptureStepLayout extends ActiveStepLayout {
                                         return;
                                     }
 
-                                    if (!countdownManager.isCountdownRunning())
+                                    boolean isFaceInPosition = (drawOverlayListener == null) ? true :
+                                        drawOverlayListener.isFaceInPosition(
+                                            new RectF(0, 0, previewView.getBitmap().getWidth(), previewView.getBitmap().getHeight()),
+                                            new RectF(0, 0, faceImage.getWidth(), faceImage.getHeight()),
+                                            faces.iterator().next().getBoundingBox());
+                                    boolean isCountdownRunning = countdownManager.isCountdownRunning();
+                                    if (!isCountdownRunning && isFaceInPosition)
                                         countdownManager.start();
+                                    else if (isCountdownRunning && !isFaceInPosition)
+                                        countdownManager.stop();
                                 } catch (Exception e) {
                                     e.printStackTrace();
                                 } finally {

--- a/backbone/src/main/res/drawable/ic_baseline_mic_24.xml
+++ b/backbone/src/main/res/drawable/ic_baseline_mic_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,14c1.66,0 2.99,-1.34 2.99,-3L15,5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v6c0,1.66 1.34,3 3,3zM17.3,11c0,3 -2.54,5.1 -5.3,5.1S6.7,14 6.7,11L5,11c0,3.41 2.72,6.23 6,6.72L11,21h2v-3.28c3.28,-0.48 6,-3.3 6,-6.72h-1.7z"/>
+</vector>

--- a/backbone/src/main/res/drawable/ic_baseline_photo_camera_24.xml
+++ b/backbone/src/main/res/drawable/ic_baseline_photo_camera_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/backbone/src/main/res/drawable/ic_baseline_photo_camera_8.xml
+++ b/backbone/src/main/res/drawable/ic_baseline_photo_camera_8.xml
@@ -1,0 +1,6 @@
+<vector android:height="8dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="8dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/backbone/src/main/res/drawable/ic_baseline_storage_24.xml
+++ b/backbone/src/main/res/drawable/ic_baseline_storage_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M2,20h20v-4L2,16v4zM4,17h2v2L4,19v-2zM2,4v4h20L22,4L2,4zM6,7L4,7L4,5h2v2zM2,14h20v-4L2,10v4zM4,11h2v2L4,13v-2z"/>
+</vector>

--- a/backbone/src/main/res/layout/active_audio_capture_step.xml
+++ b/backbone/src/main/res/layout/active_audio_capture_step.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/audioCaptureTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#2196F3"
+            android:textSize="24sp"
+            android:textStyle="bold|italic"
+            android:padding="5dp"/>
+        <TextView
+            android:id="@+id/audioCaptureDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="20dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal">
+
+            <TextView
+                android:id="@+id/audioCaptureTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="20dp"
+                android:textSize="48sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:id="@+id/audioCaptureButtonFrame"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                xmlns:app="http://schemas.android.com/apk/res-auto">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/audioCaptureButton"
+                    android:layout_width="@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_height="@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_margin="@dimen/rsb_padding_large"
+                    app:theme="@style/Base.Widget.AppCompat.ImageButton" />
+
+                <TextView
+                    style="@style/TextAppearance.AppCompat.Headline"
+                    android:id="@+id/audioCaptureButtonText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:clickable="false"
+                    android:elevation="16dp"
+                    android:textColor="@color/rsb_step_layout_tapping_button_text_color" />
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/backbone/src/main/res/layout/active_selfie_capture_step.xml
+++ b/backbone/src/main/res/layout/active_selfie_capture_step.xml
@@ -55,29 +55,14 @@
             android:gravity="bottom|center_horizontal"
             android:orientation="horizontal">
 
-            <FrameLayout
-                android:id="@+id/selfieCaptureButtonFrame"
+            <TextView
+                android:id="@+id/selfieCaptureTime"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-
-                <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/selfieCaptureButton"
-                    android:layout_width="@dimen/rsb_step_layout_tapping_interval_button_size"
-                    android:layout_height="@dimen/rsb_step_layout_tapping_interval_button_size"
-                    android:layout_margin="@dimen/rsb_padding_large"
-                    app:theme="@style/Base.Widget.AppCompat.ImageButton" />
-
-                <TextView
-                    style="@style/TextAppearance.AppCompat.Headline"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:clickable="false"
-                    android:elevation="16dp"
-                    android:text="Snap"
-                    android:textColor="@color/rsb_step_layout_tapping_button_text_color" />
-
-            </FrameLayout>
+                android:layout_height="wrap_content"
+                android:padding="20dp"
+                android:textSize="48sp"
+                android:textStyle="bold"
+                android:visibility="gone"/>
         </LinearLayout>
     </LinearLayout>
 

--- a/backbone/src/main/res/layout/active_selfie_capture_step.xml
+++ b/backbone/src/main/res/layout/active_selfie_capture_step.xml
@@ -40,7 +40,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintDimensionRatio="0.82"/>
+                app:layout_constraintDimensionRatio="0.9"/>
 
             <ImageView
                 android:id="@+id/camera_preview_overlay"
@@ -87,7 +87,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintDimensionRatio="0.65"/>
+                app:layout_constraintDimensionRatio="0.7"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout

--- a/backbone/src/main/res/layout/active_selfie_capture_step.xml
+++ b/backbone/src/main/res/layout/active_selfie_capture_step.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Capture image layout -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:id="@+id/selfieCaptureLayout"
+        android:layout_weight="20"
+        android:gravity="fill">
+
+        <TextView
+            android:id="@+id/selfieCaptureTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#2196F3"
+            android:textSize="24sp"
+            android:textStyle="bold|italic"
+            android:padding="5dp"/>
+
+        <TextView
+            android:id="@+id/selfieCaptureDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="20dp" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/camera_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="5">
+
+            <androidx.camera.view.PreviewView
+                android:id="@+id/camera_preview"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintDimensionRatio="0.82"/>
+
+            <ImageView
+                android:id="@+id/camera_preview_overlay"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_constraintTop_toTopOf="@+id/camera_preview"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="bottom|center_horizontal"
+            android:orientation="horizontal">
+
+            <FrameLayout
+                android:id="@+id/selfieCaptureButtonFrame"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/selfieCaptureButton"
+                    android:layout_width="@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_height="@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_margin="@dimen/rsb_padding_large"
+                    app:theme="@style/Base.Widget.AppCompat.ImageButton" />
+
+                <TextView
+                    style="@style/TextAppearance.AppCompat.Headline"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:clickable="false"
+                    android:elevation="16dp"
+                    android:text="Snap"
+                    android:textColor="@color/rsb_step_layout_tapping_button_text_color" />
+
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- Review image layout -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:id="@+id/selfieReviewLayout"
+        android:layout_weight="20"
+        android:gravity="fill"
+        android:visibility="gone">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="5"
+            android:padding="5dp">
+
+            <ImageView
+                android:id="@+id/selfieDisplayThumbnail"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintDimensionRatio="0.65"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal"
+            xmlns:app = "http://schemas.android.com/apk/res-auto">
+
+            <FrameLayout
+                android:layout_width = "wrap_content"
+                android:layout_height = "wrap_content"
+                android:id="@+id/selfieResetButtonFrame">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    app:theme = "@style/Base.Widget.AppCompat.ImageButton"
+                    android:id = "@+id/selfieResetButton"
+                    android:layout_width = "@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_height = "@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_margin = "@dimen/rsb_padding_large"/>
+
+                <TextView
+                    style = "@style/TextAppearance.AppCompat.Headline"
+                    android:layout_width = "wrap_content"
+                    android:layout_height = "wrap_content"
+                    android:layout_gravity = "center"
+                    android:text = "Reset"
+                    android:elevation = "16dp"
+                    android:textColor = "@color/rsb_step_layout_tapping_button_text_color"
+                    android:clickable = "false"/>
+
+            </FrameLayout>
+
+            <FrameLayout
+                android:layout_width = "wrap_content"
+                android:layout_height = "wrap_content"
+                android:id="@+id/selfieSubmitButtonFrame">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    app:theme = "@style/Base.Widget.AppCompat.ImageButton"
+                    android:id = "@+id/selfieSubmitButton"
+                    android:layout_width = "@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_height = "@dimen/rsb_step_layout_tapping_interval_button_size"
+                    android:layout_margin = "@dimen/rsb_padding_large"/>
+
+                <TextView
+                    style = "@style/TextAppearance.AppCompat.Headline"
+                    android:layout_width = "wrap_content"
+                    android:layout_height = "wrap_content"
+                    android:layout_gravity = "center"
+                    android:text = "Submit"
+                    android:elevation = "16dp"
+                    android:textColor = "@color/rsb_step_layout_tapping_button_text_color"
+                    android:clickable = "false"/>
+
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -792,4 +792,17 @@
     <string name="rsb_ax_graph_point">Point: %1$d</string>
     <string name="rsb_AX_AUDIO_BAR_GRAPH">Audio Bar Graph</string>
 
+    <!-- Permissions -->
+    <string name="rsb_permission_camera_name">Camera</string>
+    <string name="rsb_permission_camera_description">Required to take selfie image</string>
+    <string name="rsb_permission_write_external_storage_name">External Storage Write</string>
+    <string name="rsb_permission_write_external_storage_description">Required to record collected data</string>
+    <string name="rsb_permission_record_audio_name">Record Audio</string>
+    <string name="rsb_permission_record_audio_description">Required to complete audio recording collection tasks</string>
+    <string name="rsb_permission_permission_check_title">Permissions Check</string>
+    <string name="rsb_permission_permission_check_text">Please grant the requested permissions to continue</string>
+
+    <!-- Support for audio and selfie tasks -->
+    <string name="rsb_selfie_capture_test_title">Selfie Capture Test</string>
+    <string name="rsb_active_selfie_capture_test_title">Selfie Capture Active Task</string>
 </resources>

--- a/backbone/src/main/res/xml/file_paths.xml
+++ b/backbone/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="files" path="/"/>
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -43,9 +43,10 @@ allprojects {
     repositories {
         jcenter()
         google()
-        maven {
-            url "https://dl.bintray.com/touchlab/Squeaky"
-        }
+        // TODO: This URL returns 403
+//        maven {
+//            url "https://dl.bintray.com/touchlab/Squeaky"
+//        }
         maven { url "https://www.jitpack.io" }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 03 09:50:27 CDT 2018
+#Tue Nov 16 14:54:34 CST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This fork contains two new active tasks: ActiveAudioCaptureStep and ActiveSelfieCaptureStep:

- The audio capture step can be configured to record user audio for a maximum time limit, then store the data in the app's local storage as an AAC file.  Currently, the audio is using a 96K sampling rate (the highest value allowed for AAC), 256 bit encoding rate, and mono sound.
- The selfie capture step will allow users to take a picture and review it before storing it as a JPG file in the app's local storage.  This step also has some basic capability to draw custom images on the camera preview overlay (although there is no current example provided yet).  
- For both tasks, the result will contain a path to the file location inside internal storage.

Additionally, both tasks have corresponding builders and factories for easy task creation, found in the org.researchstack.backbone.task.factory and org.researchstack.backbone.task.builder packages.

